### PR TITLE
feat: display active player

### DIFF
--- a/Assets/Scripts/UI/MatchElements/InfoDisplay.cs
+++ b/Assets/Scripts/UI/MatchElements/InfoDisplay.cs
@@ -16,7 +16,11 @@ public class InfoDisplay : MonoBehaviour
 
     void UpdateText(MatchAction _)
     {
-        text.text = $"Actions: {matchHandler.Match.ActivePlayer.ActionsPoint}" +
+        string player = matchHandler.Match.ActivePlayer == matchHandler.Match.WhitePlayer
+            ? "White"
+            : "Black";
+        text.text = $"Player: {player}" +
+                    $"\nActions: {matchHandler.Match.ActivePlayer.ActionsPoint}" +
                     $"\nFocus: {matchHandler.Match.ActivePlayer.Focus}";
     }
 }


### PR DESCRIPTION
## Summary
- show which player (white or black) is active in the match info panel

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0ab37311c832cb556e922c64c7c4b